### PR TITLE
Fix typo in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ This package will observe the created and updated event of the models (check the
 In Your Form Request or Inline Validation, All You Need To Do Is Instantiate The `NotFromPasswordHistory` class passing the current user as an argument
 ``` php
 <?php
-use Infinitypaul\LaravelPasswordHistoryValidation\Models\PasswordHistoryRepo;
+use Infinitypaul\LaravelPasswordHistoryValidation\Rules\NotFromPasswordHistory;
 
 $this->validate($request, [
             'password' => [

--- a/src/LaravelPasswordHistoryValidationServiceProvider.php
+++ b/src/LaravelPasswordHistoryValidationServiceProvider.php
@@ -15,7 +15,7 @@ class LaravelPasswordHistoryValidationServiceProvider extends ServiceProvider
     {
         if ($this->app->runningInConsole()) {
             $this->publishes([
-                __DIR__.'/../config/passwordHistory.php' => config_path('password-history-validation.php'),
+                __DIR__.'/../config/passwordHistory.php' => config_path('password-history.php'),
             ], 'password-config');
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 

--- a/src/LaravelPasswordHistoryValidationServiceProvider.php
+++ b/src/LaravelPasswordHistoryValidationServiceProvider.php
@@ -16,7 +16,7 @@ class LaravelPasswordHistoryValidationServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/passwordHistory.php' => config_path('password-history-validation.php'),
-            ], 'password-config');
+            ], 'password-history');
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
             //Registering package commands.

--- a/src/LaravelPasswordHistoryValidationServiceProvider.php
+++ b/src/LaravelPasswordHistoryValidationServiceProvider.php
@@ -16,7 +16,7 @@ class LaravelPasswordHistoryValidationServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/passwordHistory.php' => config_path('password-history-validation.php'),
-            ], 'password-history');
+            ], 'password-config');
             $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
 
             //Registering package commands.


### PR DESCRIPTION
This fixes a typo in one of the examples of the README file that I found while implementing this library.