### PR TITLE
Fix composer JSON validity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8.0",
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0|^8.0",


### PR DESCRIPTION
Currently have this error when trying to composer update:

<img width="865" alt="Screenshot 2023-03-17 at 14 02 30" src="https://user-images.githubusercontent.com/2733767/225912300-ace10a05-cc69-404d-a451-d98b69dbf46a.png">

This PR removes the trailing coma